### PR TITLE
fixes JSONBConverterTest file

### DIFF
--- a/backend/peakperformance_backend/src/test/java/com/peakperformance/peakperformance_backend/converter/JSONBConverterTest.java
+++ b/backend/peakperformance_backend/src/test/java/com/peakperformance/peakperformance_backend/converter/JSONBConverterTest.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -81,9 +81,11 @@ public class JSONBConverterTest {
     }
 
     @Test
-    void testConvertToEntityAttributeCorrectlyReturnsNullWithInvalidJson() {
+    void testConvertToEntityAttributeCorrectlyThrowsExceptionWithInvalidJson() {
         jsonb = "{\"wrongObject\":12, \"SETS\":\"23\"}";
-        List<Lift> nullList = converter.convertToEntityAttribute(jsonb);
-        assertNull(nullList);
+        assertThrows(RuntimeException.class, () -> {
+            converter.convertToEntityAttribute(jsonb);
+        }, "RuntimeException should have been thrown!");
+        
     }
 }


### PR DESCRIPTION
changes the testConvertToEntityAttributeCorrectlyReturnsNullWithInvalidJson() to testConvertToEntityAttributeCorrectlyThrowsExceptionWithInvalidJson() to correctly tests the desired behavior of the convertToEntityAttribute().