### PR TITLE
fixes .env class-pathing in main method

### DIFF
--- a/backend/peakperformance_backend/src/main/java/com/peakperformance/peakperformance_backend/PeakperformanceBackendApplication.java
+++ b/backend/peakperformance_backend/src/main/java/com/peakperformance/peakperformance_backend/PeakperformanceBackendApplication.java
@@ -15,7 +15,7 @@ public class PeakperformanceBackendApplication {
 	public static void main(String[] args) {
 
 		 // Load environment variables from .env file
-        Dotenv dotenv = Dotenv.configure().directory("backend/peakperformance_backend/.env").load();
+        Dotenv dotenv = Dotenv.configure().filename(".env").load();
 		
 
         // Set system properties


### PR DESCRIPTION
points Dotenv configurer to .env's place in resources to rely on class paths and not file pathing, allowing for 

``
./mvnw spring-boot:run
``

to work