### PR TITLE
feat!: create CRUD endpoints for movement app

### DIFF
--- a/backend/docker/docker-compose.yaml
+++ b/backend/docker/docker-compose.yaml
@@ -36,5 +36,22 @@ services:
     ports:
       - "5432:5432"
 
+  test:
+    build: 
+      context: ..
+      dockerfile: docker/Dockerfile
+    environment:
+      - DEBUG=1
+      - SECRET_KEY=${SECRET_KEY}
+      - ALLOWED_HOSTS=${ALLOWED_HOSTS}
+      - POSTGRES_DB=${POSTGRES_DB}
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - DB_HOST=db
+      - DB_PORT=5432
+    depends_on:
+      - db
+    command: python manage.py test
+
 volumes:
   postgres_data:

--- a/backend/docker/docker-compose.yaml
+++ b/backend/docker/docker-compose.yaml
@@ -21,7 +21,7 @@ services:
       - db
 
     command: >
-      sh -c "python manage.py migrate &&
+      sh -c "python manage.py makemigrations && python manage.py migrate &&
              python manage.py runserver 0.0.0.0:8000"  
     
   db:

--- a/backend/docker/docker-compose.yaml
+++ b/backend/docker/docker-compose.yaml
@@ -51,7 +51,7 @@ services:
       - DB_PORT=5432
     depends_on:
       - db
-    command: python manage.py test
+    command: python -m pytest users/tests.py movement/tests.py workout/tests.py -v
 
 volumes:
   postgres_data:

--- a/backend/docs/developer/run_server.md
+++ b/backend/docs/developer/run_server.md
@@ -1,4 +1,4 @@
-# Running Development Server for PeakPerformance
+# Running Development Backend Server for PeakPerformance
 
 This documentation explains how to run the PeakPerformance backend server using Docker.
 
@@ -10,7 +10,7 @@ Before you begin, ensure you have the following installed on your system:
 ## 1. Starting the Server
 
 - Ensure you are in the `PeakPerformance/backend` directory
-- To build the container run the following command:
+- To build the container, run the following command:
 
 ```bash
 python scripts/run_server.py
@@ -24,21 +24,32 @@ python scripts/run_server.py
 
 - To access the admin endpoint:
 
-```url
+```bash
 localhost:8000/admin/
 ```
 
 - To access user endpoints:
 
-```url
-localhost:8000/peakperformance_backend/users/user-info/
-localhost:8000/peakperformance_backend/users/register/
-localhost:8000/peakperformance_backend/users/login/
-localhost:8000/peakperformance_backend/users/logout/
-localhost:8000/peakperformance_backend/users/refresh/
-localhost:8000/peakperformance_backend/users/verify-2fa/
-localhost:8000/peakperformance_backend/users/password-reset/
-localhost:8000/peakperformance_backend/users/password-reset/confirm/
+```bash
+localhost:8000/api/users/user-info/
+localhost:8000/api/users/register/
+localhost:8000/api/users/login/
+localhost:8000/api/users/logout/
+localhost:8000/api/users/refresh/
+localhost:8000/api/users/verify-2fa/
+localhost:8000/api/users/password-reset/
+localhost:8000/api/users/password-reset/confirm/
+```
+
+- To access movement endpoints:
+
+```bash
+localhost:8000/api/movements
+```
+
+- To access muscles endpoints:
+```bash
+localhost:8000/api/muscles
 ```
 
 ## 4. Stopping the Server

--- a/backend/docs/developer/run_tests.md
+++ b/backend/docs/developer/run_tests.md
@@ -1,0 +1,19 @@
+# Running Development Server for PeakPerformance
+
+This documentation explains how to run the PeakPerformance backend test suite using Docker.
+
+Before you begin, ensure you have the following installed on your system:
+
+- [Docker](https://docs.docker.com/get-docker/)
+- [Docker Compose](https://docs.docker.com/compose/install/) (usually included with Docker Desktop)
+
+## Running Tests
+
+- Ensure you are in the `PeakPerformance/backend` directory
+- To build the testing container, run the following command:
+
+```bash
+python scripts/run_tests.py
+```
+
+Test results will be logged in the terminal, and the container will stop and delete itself once the all tests have been ran.

--- a/backend/movement/models.py
+++ b/backend/movement/models.py
@@ -25,7 +25,7 @@ class Movement(models.Model):
     movement_image_url = models.TextField(blank=True) # could use this in future to link to a S3 or Azure Storage that holds image of movement for frontend
     
     def __str__(self):
-        return self.movement_name
+        return self.name
     
     class Meta:
         ordering = ['name']

--- a/backend/movement/permissions.py
+++ b/backend/movement/permissions.py
@@ -6,3 +6,4 @@ only allows requests by admin level users
 class IsAdminUser(permissions.BasePermission):
     def has_permission(self, request, view):
         return bool(request.user and request.user.is_staff)
+    

--- a/backend/movement/permissions.py
+++ b/backend/movement/permissions.py
@@ -3,6 +3,6 @@ from rest_framework import permissions
 '''
 only allows requests by admin level users
 '''
-class isAdminUser(permissions.BasePermission):
-    def has_permission(self, request):
+class IsAdminUser(permissions.BasePermission):
+    def has_permission(self, request, view):
         return bool(request.user and request.user.is_staff)

--- a/backend/movement/permissions.py
+++ b/backend/movement/permissions.py
@@ -1,0 +1,8 @@
+from rest_framework import permissions
+
+'''
+only allows requests by admin level users
+'''
+class isAdminUser(permissions.BasePermission):
+    def has_permission(self, request):
+        return bool(request.user and request.user.is_staff)

--- a/backend/movement/serializers.py
+++ b/backend/movement/serializers.py
@@ -17,4 +17,4 @@ class MovementSerializer(ModelSerializer):
     
     class Meta:
         model = Movement
-        fields = ['id', 'name', 'muscles_worked', 'type', 'movement_image_url']
+        fields = ['name', 'muscles_worked', 'type', 'movement_image_url']

--- a/backend/movement/serializers.py
+++ b/backend/movement/serializers.py
@@ -1,6 +1,5 @@
-from rest_framework.serializers import ModelSerializer
+from rest_framework.serializers import ModelSerializer,PrimaryKeyRelatedField
 
-from backend.users import serializers
 from .models import Muscle, Movement
 
 class MuscleSerializer(ModelSerializer):
@@ -10,7 +9,7 @@ class MuscleSerializer(ModelSerializer):
         
 class MovementSerializer(ModelSerializer):
     #finds the muscle entries in db to create entries in junction table
-    muscles_worked = serializers.PrimaryKeyRelatedField(
+    muscles_worked = PrimaryKeyRelatedField(
         queryset=Muscle.objects.all(),
         many=True,
         required=False

--- a/backend/movement/serializers.py
+++ b/backend/movement/serializers.py
@@ -1,0 +1,21 @@
+from rest_framework.serializers import ModelSerializer
+
+from backend.users import serializers
+from .models import Muscle, Movement
+
+class MuscleSerializer(ModelSerializer):
+    class Meta:
+        model = Muscle
+        fields = ('name', 'category')
+        
+class MovementSerializer(ModelSerializer):
+    #finds the muscle entries in db to create entries in junction table
+    muscles_worked = serializers.PrimaryKeyRelatedField(
+        queryset=Muscle.objects.all(),
+        many=True,
+        required=False
+    )
+    
+    class Meta:
+        model = Movement
+        fields = ['id', 'name', 'muscles_worked', 'type', 'movement_image_url']

--- a/backend/movement/tests.py
+++ b/backend/movement/tests.py
@@ -1,3 +1,74 @@
-from django.test import TestCase
+from rest_framework.test import APITestCase
+from rest_framework import status
+
+from users.models import CustomUser
+
+from .models import Muscle, Movement
+
 
 # Create your tests here.
+class MovementAPITest(APITestCase):
+    
+    def setUp(self):
+        # Create admin user
+        self.admin = CustomUser.objects.create_user(
+            email='admin@example.com',
+            username='admin',
+            password='password123',
+            is_staff=True
+        )
+        #use for later
+        muscle, _ = Muscle.objects.get_or_create(
+            name = 'Biceps',
+            category = 'arms'
+        )
+        self.biceps = muscle
+        
+        #create Dtos
+        self.muscleDto = {
+            'name':'Triceps',
+            'category':'arms'
+        }
+        
+        self.movementDto = {
+            'name':'Supinated Curls',
+            'muscles_worked':[self.biceps.pk],
+            'type':'strength',
+            'movement_image_url':'https://image.com/supinated-curls'
+        }
+    
+    def test_create_muscle_entry(self):
+        #Arrange
+        self.client.force_authenticate(user=self.admin)
+        
+        #Act
+        response = self.client.post('/api/muscles/', self.muscleDto, format='json')
+        
+        #Assert
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(Muscle.objects.count(), 2)
+        
+        #check DB
+        new_muscle_entry = Muscle.objects.get(name = 'Triceps')
+        self.assertEqual(new_muscle_entry.name, 'Triceps')
+        self.assertEqual(new_muscle_entry.category, 'arms')
+    
+    def test_create_movement_entry(self):
+        #Arrange
+        self.client.force_authenticate(user=self.admin)
+        
+        #Act
+        response = self.client.post('/api/movements/', self.movementDto, format='json')
+        
+        #Assert
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(Movement.objects.count(), 1)
+        
+        #check DB 
+        new_movement_entry = Movement.objects.get(name='Supinated Curls')
+        self.assertEqual(new_movement_entry.name, 'Supinated Curls')
+        self.assertEqual(new_movement_entry.type, 'strength')
+        muscle_ids = list(new_movement_entry.muscles_worked.values_list('id', flat=True)) # muscle table entries
+        self.assertEqual(muscle_ids, [self.biceps.pk])
+        self.assertEqual(new_movement_entry.movement_image_url, 'https://image.com/supinated-curls')
+        

--- a/backend/movement/tests.py
+++ b/backend/movement/tests.py
@@ -9,7 +9,7 @@ from .models import Muscle, Movement
 
 # Create your tests here.
 class MovementAPITest(APITestCase):
-    
+
     def setUp(self):
         # Create admin user
         self.admin = CustomUser.objects.create_user(
@@ -18,6 +18,12 @@ class MovementAPITest(APITestCase):
             password='password123',
             is_staff=True
         )
+        self.user = CustomUser.objects.create_user(
+            email='user@example.com',
+            username='user',
+            password='password',
+            is_staff=False
+        )
         #use for later
         muscle, _ = Muscle.objects.get_or_create(
             name = 'Biceps',
@@ -25,10 +31,21 @@ class MovementAPITest(APITestCase):
         )
         self.biceps = muscle
         
+        muscle2, _ = Muscle.objects.get_or_create(
+            name = 'Hamstring',
+            category = 'legs'
+        )
+        self.hamstrings = muscle2
+        
         #create Dtos
         self.muscleDto = {
             'name':'Triceps',
             'category':'arms'
+        }
+        
+        self.muscleDto2 = {
+            'name':'Upper-Chest',
+            'category':'Chest'
         }
         
         self.movementDto = {
@@ -37,7 +54,14 @@ class MovementAPITest(APITestCase):
             'type':'strength',
             'movement_image_url':'https://image.com/supinated-curls'
         }
-    
+        
+        self.movementDto2 = {
+            'name':'Romanian Deadlift',
+            'muscles_worked':[self.hamstrings.pk],
+            'type':'strength',
+            'movement_image_url':'https://image.com/supinated-curls'
+        }
+
     def test_create_muscle_entry(self):
         #Arrange
         self.client.force_authenticate(user=self.admin)
@@ -47,13 +71,25 @@ class MovementAPITest(APITestCase):
         
         #Assert
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(Muscle.objects.count(), 2)
+        self.assertEqual(Muscle.objects.count(), 3)
         
         #check DB
         new_muscle_entry = Muscle.objects.get(name = 'Triceps')
         self.assertEqual(new_muscle_entry.name, 'Triceps')
         self.assertEqual(new_muscle_entry.category, 'arms')
-    
+
+    def test_create_muscle_entry_by_non_admin(self):
+        #Arrange
+        self.client.force_login(self.user)
+        
+        #Act
+        response = self.client.post('/api/muscles/', self.muscleDto, format='json')
+        
+        #Assert
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(Muscle.objects.count(), 2)
+        self.assertRaises(Muscle.DoesNotExist, lambda: Muscle.objects.get(name = 'Upper-Chest'))
+
     def test_create_movement_entry(self):
         #Arrange
         self.client.force_authenticate(user=self.admin)
@@ -65,11 +101,22 @@ class MovementAPITest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(Movement.objects.count(), 1)
         
-        #check DB 
+        #check DB
         new_movement_entry = Movement.objects.get(name='Supinated Curls')
         self.assertEqual(new_movement_entry.name, 'Supinated Curls')
         self.assertEqual(new_movement_entry.type, 'strength')
         muscle_ids = list(new_movement_entry.muscles_worked.values_list('id', flat=True)) # muscle table entries
         self.assertEqual(muscle_ids, [self.biceps.pk])
         self.assertEqual(new_movement_entry.movement_image_url, 'https://image.com/supinated-curls')
+
+    def test_create_movement_entry_by_non_admin(self):
+        #Arrange
+        self.client.force_authenticate(user=self.user)
         
+        #Act
+        response = self.client.post('/api/movements/', self.movementDto2, format='json')
+        
+        #Assert
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(Movement.objects.count(), 0)
+        self.assertRaises(Movement.DoesNotExist, lambda: Movement.objects.get(name = 'Romanian Deadlift'))

--- a/backend/movement/tests.py
+++ b/backend/movement/tests.py
@@ -1,3 +1,4 @@
+import pytest
 from rest_framework.test import APITestCase
 from rest_framework import status
 

--- a/backend/movement/tests.py
+++ b/backend/movement/tests.py
@@ -1,4 +1,3 @@
-import pytest
 from rest_framework.test import APITestCase
 from rest_framework import status
 
@@ -120,3 +119,223 @@ class MovementAPITest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(Movement.objects.count(), 0)
         self.assertRaises(Movement.DoesNotExist, lambda: Movement.objects.get(name = 'Romanian Deadlift'))
+
+    def test_get_muscle_list(self):
+        # Arrange
+        self.client.force_authenticate(user=self.user)
+        
+        # Act
+        response = self.client.get('/api/muscles/', format='json')
+        
+        # Assert
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 2)  # Should only return the two muscles created in setUp
+
+    def test_get_muscle_detail(self):
+        # Arrange
+        self.client.force_authenticate(user=self.user)
+        
+        # Act
+        response = self.client.get(f'/api/muscles/{self.biceps.pk}/', format='json')
+        
+        # Assert
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['name'], 'Biceps')
+        self.assertEqual(response.data['category'], 'arms')
+
+    def test_update_muscle_by_admin(self):
+        # Arrange
+        self.client.force_authenticate(user=self.admin)
+        updated_data = {
+            'name': 'Biceps Brachii',
+            'category': 'arms'
+        }
+        
+        # Act
+        response = self.client.put(f'/api/muscles/{self.biceps.pk}/', updated_data, format='json')
+        
+        # Assert
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        
+        # Check DB
+        updated_muscle = Muscle.objects.get(pk=self.biceps.pk)
+        self.assertEqual(updated_muscle.name, 'Biceps Brachii')
+        self.assertEqual(updated_muscle.category, 'arms')
+
+    def test_update_muscle_by_non_admin(self):
+        # Arrange
+        self.client.force_authenticate(user=self.user)
+        updated_data = {
+            'name': 'Biceps Brachii',
+            'category': 'upper arms'
+        }
+        
+        # Act
+        response = self.client.put(f'/api/muscles/{self.biceps.pk}/', updated_data, format='json')
+        
+        # Assert
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        
+        # Check DB - should be unchanged
+        unchanged_muscle = Muscle.objects.get(pk=self.biceps.pk)
+        self.assertEqual(unchanged_muscle.name, 'Biceps')
+        self.assertEqual(unchanged_muscle.category, 'arms')
+
+    def test_delete_muscle_by_admin(self):
+        # Arrange
+        self.client.force_authenticate(user=self.admin)
+        
+        # Act
+        response = self.client.delete(f'/api/muscles/{self.biceps.pk}/', format='json')
+        
+        # Assert
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(Muscle.objects.count(), 1)  # Only hamstrings should remain
+        self.assertRaises(Muscle.DoesNotExist, lambda: Muscle.objects.get(pk=self.biceps.pk))
+
+    def test_delete_muscle_by_non_admin(self):
+        # Arrange
+        self.client.force_authenticate(user=self.user)
+        
+        # Act
+        response = self.client.delete(f'/api/muscles/{self.biceps.pk}/', format='json')
+        
+        # Assert
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(Muscle.objects.count(), 2)  # Both muscles should still exist
+
+    # Now for Movement tests
+    def test_get_movement_list(self):
+        # Arrange - First create a movement to list
+        self.client.force_authenticate(user=self.admin)
+        self.client.post('/api/movements/', self.movementDto, format='json')
+        
+        # Force authenticate with regular user
+        self.client.force_authenticate(user=self.user)
+        
+        # Act
+        response = self.client.get('/api/movements/', format='json')
+        
+        # Assert
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+
+    def test_get_movement_detail(self):
+        # Arrange - First create a movement
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.post('/api/movements/', self.movementDto, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        
+        # Get the movement from the database instead of response
+        created_movement = Movement.objects.get(name=self.movementDto['name'])
+        movement_id = created_movement.pk
+        
+        # Force authenticate with regular user
+        self.client.force_authenticate(user=self.user)
+        
+        # Act
+        response = self.client.get(f'/api/movements/{movement_id}/', format='json')
+        
+        # Assert
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['name'], 'Supinated Curls')
+        self.assertEqual(response.data['type'], 'strength')
+        self.assertEqual(response.data['movement_image_url'], 'https://image.com/supinated-curls')
+        self.assertEqual(response.data['muscles_worked'], [self.biceps.pk])
+
+    def test_update_movement_by_admin(self):
+        # Arrange - First create a movement
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.post('/api/movements/', self.movementDto, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        
+        # Get the movement from the database
+        created_movement = Movement.objects.get(name=self.movementDto['name'])
+        movement_id = created_movement.pk
+        
+        updated_data = {
+            'name': 'Hammer Curls',
+            'muscles_worked': [self.biceps.pk],
+            'type': 'strength',
+            'movement_image_url': 'https://image.com/hammer-curls'
+        }
+        
+        # Act
+        response = self.client.put(f'/api/movements/{movement_id}/', updated_data, format='json')
+        
+        # Assert
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        
+        # Check DB
+        updated_movement = Movement.objects.get(pk=movement_id)
+        self.assertEqual(updated_movement.name, 'Hammer Curls')
+        self.assertEqual(updated_movement.movement_image_url, 'https://image.com/hammer-curls')
+
+    def test_update_movement_by_non_admin(self):
+        # Arrange - First create a movement
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.post('/api/movements/', self.movementDto, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        
+        # Get the movement from the database
+        created_movement = Movement.objects.get(name=self.movementDto['name'])
+        movement_id = created_movement.pk
+        
+        # Switch to non-admin user
+        self.client.force_authenticate(user=self.user)
+        
+        updated_data = {
+            'name': 'Hammer Curls',
+            'muscles_worked': [self.biceps.pk],
+            'type': 'strength',
+            'movement_image_url': 'https://image.com/hammer-curls'
+        }
+        
+        # Act
+        response = self.client.put(f'/api/movements/{movement_id}/', updated_data, format='json')
+        
+        # Assert
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        
+        # Check DB - should be unchanged
+        unchanged_movement = Movement.objects.get(pk=movement_id)
+        self.assertEqual(unchanged_movement.name, 'Supinated Curls')
+
+    def test_delete_movement_by_admin(self):
+        # Arrange - First create a movement
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.post('/api/movements/', self.movementDto, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        
+        # Get the movement from the database
+        created_movement = Movement.objects.get(name=self.movementDto['name'])
+        movement_id = created_movement.pk
+        
+        # Act
+        response = self.client.delete(f'/api/movements/{movement_id}/', format='json')
+        
+        # Assert
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(Movement.objects.count(), 0)
+        self.assertRaises(Movement.DoesNotExist, lambda: Movement.objects.get(pk=movement_id))
+
+    def test_delete_movement_by_non_admin(self):
+        # Arrange - First create a movement
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.post('/api/movements/', self.movementDto, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        
+        # Get the movement from the database
+        created_movement = Movement.objects.get(name=self.movementDto['name'])
+        movement_id = created_movement.pk
+    
+        
+        # Switch to non-admin user
+        self.client.force_authenticate(user=self.user)
+        
+        # Act
+        response = self.client.delete(f'/api/movements/{movement_id}/', format='json')
+        
+        # Assert
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(Movement.objects.count(), 1)  # Movement should still exist

--- a/backend/movement/urls.py
+++ b/backend/movement/urls.py
@@ -1,0 +1,15 @@
+from django.urls import path, include
+from rest_framework.routers import DefaultRouter
+from rest_framework.routers import DefaultRouter
+from .views import MuscleViewSet, MovementViewSet
+
+'''
+different router must be used in order to have different endpoint pathing
+otherwise for muscle will be 'movement/muscle' and movement will be 'movement/movement'
+'''
+muscle_router = DefaultRouter()
+muscle_router.register('', MuscleViewSet)
+movement_router = DefaultRouter()
+movement_router.register('', MovementViewSet)
+muscle_patterns = [path('', include(muscle_router.urls)),]
+movement_patterns = [path('', include(movement_router.urls)),]

--- a/backend/movement/views.py
+++ b/backend/movement/views.py
@@ -1,3 +1,3 @@
-from django.shortcuts import render
+
 
 # Create your views here.

--- a/backend/movement/views.py
+++ b/backend/movement/views.py
@@ -1,3 +1,24 @@
-
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.viewsets import ModelViewSet
+from models import Muscle, Movement
+from .permissions import IsAdminUser
+from .serializers import MuscleSerializer, MovementSerializer
 
 # Create your views here.
+"""
+API view to create a new muscle entry.
+Only admin users can create new muscles.
+"""
+class MuscleViewSet(ModelViewSet):
+    serializer_class = MuscleSerializer
+    permission_classes = [IsAuthenticated, IsAdminUser]
+    queryset = Muscle.objects.all()
+
+"""
+API view to create a new movement entry.
+Only admin users can create new movements.
+"""
+class MovementViewSet(ModelViewSet):
+    serializer_class = MovementSerializer
+    permission_classes = [IsAuthenticated, IsAdminUser]
+    queryset = Movement.objects.all()

--- a/backend/movement/views.py
+++ b/backend/movement/views.py
@@ -1,6 +1,6 @@
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.viewsets import ModelViewSet
-from models import Muscle, Movement
+from .models import Muscle, Movement
 from .permissions import IsAdminUser
 from .serializers import MuscleSerializer, MovementSerializer
 

--- a/backend/movement/views.py
+++ b/backend/movement/views.py
@@ -7,8 +7,8 @@ from .serializers import MuscleSerializer, MovementSerializer
 # Create your views here.
 
 """
-API view to create a new muscle entry.
-Only admin users can create new muscles.
+CRUD API view a new muscle entry.
+Only admin users have writing & reading privileges. Regular users are only allowed reading privileges
 """
 class MuscleViewSet(ModelViewSet):
     serializer_class = MuscleSerializer
@@ -22,8 +22,8 @@ class MuscleViewSet(ModelViewSet):
         return [permission() for permission in permission_classes]
 
 """
-API view to create a new movement entry.
-Only admin users can create new movements.
+CRUD API view a new movement entry.
+Only admin users have writing & reading privileges. Regular users are only allowed reading privileges
 """
 class MovementViewSet(ModelViewSet):
     serializer_class = MovementSerializer

--- a/backend/movement/views.py
+++ b/backend/movement/views.py
@@ -5,14 +5,21 @@ from .permissions import IsAdminUser
 from .serializers import MuscleSerializer, MovementSerializer
 
 # Create your views here.
+
 """
 API view to create a new muscle entry.
 Only admin users can create new muscles.
 """
 class MuscleViewSet(ModelViewSet):
     serializer_class = MuscleSerializer
-    permission_classes = [IsAuthenticated, IsAdminUser]
     queryset = Muscle.objects.all()
+    
+    def get_permissions(self):
+        if self.action in ['list', 'retrieve']:
+            permission_classes = [IsAuthenticated]
+        else:
+            permission_classes = [IsAuthenticated, IsAdminUser]
+        return [permission() for permission in permission_classes]
 
 """
 API view to create a new movement entry.
@@ -20,5 +27,11 @@ Only admin users can create new movements.
 """
 class MovementViewSet(ModelViewSet):
     serializer_class = MovementSerializer
-    permission_classes = [IsAuthenticated, IsAdminUser]
     queryset = Movement.objects.all()
+    
+    def get_permissions(self):
+        if self.action in ['list', 'retrieve']:
+            permission_classes = [IsAuthenticated]
+        else:
+            permission_classes = [IsAuthenticated, IsAdminUser]
+        return [permission() for permission in permission_classes]

--- a/backend/peakperformance_backend/conftest.py
+++ b/backend/peakperformance_backend/conftest.py
@@ -1,0 +1,7 @@
+# conftest.py
+import pytest
+from rest_framework.test import APIClient
+
+@pytest.fixture
+def api_client():
+    return APIClient()

--- a/backend/peakperformance_backend/pytest.ini
+++ b/backend/peakperformance_backend/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = peakperformance_backend.test_settings
+python_files = tests.py test_*.py *_tests.py
+testpaths = users movement workout

--- a/backend/peakperformance_backend/urls.py
+++ b/backend/peakperformance_backend/urls.py
@@ -16,8 +16,11 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path, include
+from movement.urls import muscle_patterns, movement_patterns
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('peakperformance_backend/users/', include('users.urls'))
+    path('api/users/', include('users.urls')),
+    path('api/muscles/', include(muscle_patterns)),
+    path('api/movements/', include(movement_patterns)),
 ]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,4 +7,6 @@ PyJWT
 pytz
 python-dotenv
 psycopg2-binary
+pytest
+pytest-django
 gunicorn

--- a/backend/scripts/run_tests.py
+++ b/backend/scripts/run_tests.py
@@ -1,0 +1,26 @@
+import os
+import subprocess
+from pathlib import Path
+import platform
+from run_server import load_env_files, delete_old_image_and_container, build_image
+
+'''
+Loads env variables into terminal before building image, then running tests inside using docker-compose
+'''
+
+docker_path = Path.cwd()/'docker'
+is_os_windows = platform.system() == 'Windows' #windows needs shell otherwise permissions errors will not let script run processes
+
+def run_test_suite():
+    print("RUNNING TESTS")
+    process = subprocess.run(['docker-compose', 'run', '--rm', 'test'], cwd=docker_path, shell=is_os_windows)
+    print(process)
+
+def main():
+    load_env_files()
+    delete_old_image_and_container()
+    build_image()
+    run_test_suite()
+
+if __name__ == '__main__':
+    main()

--- a/backend/users/tests.py
+++ b/backend/users/tests.py
@@ -29,7 +29,7 @@ class UserAPITest(APITestCase):
     
     def test_create_user(self):
         """Test user registration"""
-        response = self.client.post('/api/users/register/', self.valid_register_data, format='json')
+        response = self.client.post('/peak_performance_backend/users/register/', self.valid_register_data, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(CustomUser.objects.count(), 2)  # Our test user + new user
         
@@ -41,7 +41,7 @@ class UserAPITest(APITestCase):
     def test_login_flow(self):
         """Test the two-factor authentication login flow"""
         # Step 1: Login request should return a message about 2FA code sent
-        response = self.client.post('/api/users/login/', self.valid_login_data, format='json')
+        response = self.client.post('/peak_performance_backend/users/login/', self.valid_login_data, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn('message', response.data)
         self.assertIn('verification code', response.data['message'].lower())
@@ -58,7 +58,7 @@ class UserAPITest(APITestCase):
             'code': code_obj.code
         }
         
-        response = self.client.post('/api/users/verify-2fa/', verify_data, format='json')
+        response = self.client.post('/peak_performance_backend/users/verify-2fa/', verify_data, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         
         # Verify response contains user data and cookies were set
@@ -85,13 +85,13 @@ class UserAPITest(APITestCase):
             'password': 'wrongpassword'
         }
         
-        response = self.client.post('/api/users/login/', invalid_data, format='json')
+        response = self.client.post('/peak_performance_backend/users/login/', invalid_data, format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
     
     def test_invalid_2fa_code(self):
         """Test using an invalid 2FA code"""
         # First login to generate a 2FA code
-        self.client.post('/api/users/login/', self.valid_login_data, format='json')
+        self.client.post('/peak_performance_backend/users/login/', self.valid_login_data, format='json')
         
         # Try with wrong code
         invalid_verify_data = {
@@ -99,13 +99,13 @@ class UserAPITest(APITestCase):
             'code': '000000'  # Wrong code
         }
         
-        response = self.client.post('/api/users/verify-2fa/', invalid_verify_data, format='json')
+        response = self.client.post('/peak_performance_backend/users/verify-2fa/', invalid_verify_data, format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
     
     def test_expired_2fa_code(self):
         """Test using an expired 2FA code"""
         # First login to generate a 2FA code
-        self.client.post('/api/users/login/', self.valid_login_data, format='json')
+        self.client.post('/peak_performance_backend/users/login/', self.valid_login_data, format='json')
         
         # Get the code and manually expire it
         code_obj = TwoFactorCode.objects.get(user=self.test_user)
@@ -118,13 +118,13 @@ class UserAPITest(APITestCase):
             'code': code_obj.code
         }
         
-        response = self.client.post('/api/users/verify-2fa/', verify_data, format='json')
+        response = self.client.post('/peak_performance_backend/users/verify-2fa/', verify_data, format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
     
     def test_logout(self):
         """Test user logout functionality"""
         # First login and get authenticated
-        self.client.post('/api/users/login/', self.valid_login_data, format='json')
+        self.client.post('/peak_performance_backend/users/login/', self.valid_login_data, format='json')
         code_obj = TwoFactorCode.objects.get(user=self.test_user)
         
         verify_data = {
@@ -132,10 +132,10 @@ class UserAPITest(APITestCase):
             'code': code_obj.code
         }
         
-        self.client.post('/api/users/verify-2fa/', verify_data, format='json')
+        self.client.post('/peak_performance_backend/users/verify-2fa/', verify_data, format='json')
         
         # Then logout
-        response = self.client.post('/api/users/logout/', {}, format='json')
+        response = self.client.post('/peak_performance_backend/users/logout/', {}, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         
         # Verify cookies were deleted
@@ -148,7 +148,7 @@ class UserAPITest(APITestCase):
         self.client.force_authenticate(user=self.test_user)
         
         # Get user info
-        response = self.client.get('/api/users/user-info/')
+        response = self.client.get('/peak_performance_backend/users/user-info/')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['email'], self.test_user.email)
         self.assertEqual(response.data['username'], self.test_user.username)
@@ -156,7 +156,7 @@ class UserAPITest(APITestCase):
     def test_token_refresh(self):
         """Test JWT token refresh functionality"""
         # First login and authenticate to get tokens
-        self.client.post('/api/users/login/', self.valid_login_data, format='json')
+        self.client.post('/peak_performance_backend/users/login/', self.valid_login_data, format='json')
         code_obj = TwoFactorCode.objects.get(user=self.test_user)
         
         verify_data = {
@@ -164,20 +164,20 @@ class UserAPITest(APITestCase):
             'code': code_obj.code
         }
         
-        auth_response = self.client.post('/api/users/verify-2fa/', verify_data, format='json')
+        auth_response = self.client.post('/peak_performance_backend/users/verify-2fa/', verify_data, format='json')
         
         # Force client to use the cookies from the auth response
         self.client.cookies = auth_response.cookies
         
         # Request a token refresh
-        response = self.client.post('/api/users/refresh/')
+        response = self.client.post('/peak_performance_backend/users/refresh/')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn('access_token', response.cookies)
     
     def test_password_reset_request(self):
         """Test requesting a password reset"""
         # Request password reset
-        response = self.client.post('/api/users/password-reset/', {'email': 'testuser@example.com'}, format='json')
+        response = self.client.post('/peak_performance_backend/users/password-reset/', {'email': 'testuser@example.com'}, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         
         # Verify token was created
@@ -186,13 +186,13 @@ class UserAPITest(APITestCase):
     def test_password_reset_invalid_email(self):
         """Test password reset with non-existent email"""
         # Request password reset with non-existent email
-        response = self.client.post('/api/users/password-reset/', {'email': 'nonexistent@example.com'}, format='json')
+        response = self.client.post('/peak_performance_backend/users/password-reset/', {'email': 'nonexistent@example.com'}, format='json')
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
     
     def test_password_reset_confirm(self):
         """Test confirming a password reset"""
         # First request a password reset
-        self.client.post('/api/users/password-reset/', {'email': 'testuser@example.com'}, format='json')
+        self.client.post('/peak_performance_backend/users/password-reset/', {'email': 'testuser@example.com'}, format='json')
         
         # Get the token
         token_obj = PasswordResetToken.objects.get(user=self.test_user)
@@ -203,7 +203,7 @@ class UserAPITest(APITestCase):
             'password': 'newpassword123'
         }
         
-        response = self.client.post('/api/users/password-reset/confirm/', reset_data, format='json')
+        response = self.client.post('/peak_performance_backend/users/password-reset/confirm/', reset_data, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         
         # Verify password was changed
@@ -221,13 +221,13 @@ class UserAPITest(APITestCase):
             'password': 'newpassword123'
         }
         
-        response = self.client.post('/api/users/password-reset/confirm/', reset_data, format='json')
+        response = self.client.post('/peak_performance_backend/users/password-reset/confirm/', reset_data, format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
     
     def test_password_reset_expired_token(self):
         """Test password reset with expired token"""
         # First request a password reset
-        self.client.post('/api/users/password-reset/', {'email': 'testuser@example.com'}, format='json')
+        self.client.post('/peak_performance_backend/users/password-reset/', {'email': 'testuser@example.com'}, format='json')
         
         # Get the token and manually expire it
         token_obj = PasswordResetToken.objects.get(user=self.test_user)
@@ -240,5 +240,5 @@ class UserAPITest(APITestCase):
             'password': 'newpassword123'
         }
         
-        response = self.client.post('/api/users/password-reset/confirm/', reset_data, format='json')
+        response = self.client.post('/peak_performance_backend/users/password-reset/confirm/', reset_data, format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
The `movement` app now has CRUD related endpoints with test accompanied to verify their behavior. Also, a `scripts/run_ tests.py` has been  made to create a test container to run our test suite.

# ***TODO***
- Various tests from the `users` app are currently failing and should be addressed
- We should think about creating a CI Pipeline for our changes to make sure they are tested before any merging can occur.