### PR TITLE
refactor: edit backend scripts to use command line arguments to determine environment

### DIFF
--- a/backend/docs/developer/build_image.md
+++ b/backend/docs/developer/build_image.md
@@ -13,7 +13,7 @@ Before you begin, ensure you have the following installed on your system:
 - To build the container run the following command:
 
 ```bash
-python scripts/build_image.py
+python scripts/build_image.py --env dev
 ```
 
 This will build PeakPerformance's Django backend image with the newest changes done.

--- a/backend/docs/developer/run_server.md
+++ b/backend/docs/developer/run_server.md
@@ -13,7 +13,7 @@ Before you begin, ensure you have the following installed on your system:
 - To build the container, run the following command:
 
 ```bash
-python scripts/run_server.py
+python scripts/run_server.py --env dev
 ```
 
 ## 2. Accessing the Server

--- a/backend/docs/developer/run_tests.md
+++ b/backend/docs/developer/run_tests.md
@@ -13,7 +13,7 @@ Before you begin, ensure you have the following installed on your system:
 - To build the testing container, run the following command:
 
 ```bash
-python scripts/run_tests.py
+python scripts/run_tests.py --env dev
 ```
 
 Test results will be logged in the terminal, and the container will stop and delete itself once the all tests have been ran.

--- a/backend/scripts/build_image.py
+++ b/backend/scripts/build_image.py
@@ -5,21 +5,19 @@ import subprocess
 import argparse
 
 cd = Path.cwd()
-docker_path = None # checking if this is a pipeline being ran, since its a linux machine
 is_os_windows = platform.system() == 'Windows' #windows needs shell otherwise permissions errors will not let script run processes
 
-def determine_environment():
-    print('SETTING ENVIRONMENT SPECIFIC VALUES')
+        
+def determine_docker_path():
     parser = argparse.ArgumentParser(description='environment flag')
     parser.add_argument('--env', type=str, choices=['dev', 'ci'], default='dev', help='Specify the environment (dev or ci)')
     args = parser.parse_args()
     global docker_path
-    if args == 'dev':
-        docker_path = cd/'docker'
+    if args.env == 'dev':
+        return cd/'docker'
     else:
-        docker_path = cd/'backend'/'docker'
-    
-    
+        return cd/'backend'/'docker'
+
 def load_env_files():
     print('LOADING ENVIRONMENT VARIABLES')
     file_path = cd/'.env'
@@ -38,7 +36,9 @@ def delete_old_image_and_container():
     print('DELETING OLD IMAGE AND CONTAINER')
     process = subprocess.run(['docker', 'rmi', 'docker-web', '--force'], cwd=Path.cwd(), shell=is_os_windows)
     print(process)
+    
 
+docker_path = determine_docker_path()
 def build_image():
     print('BUILDING IMAGE WITH NEW CHANGES')
     process = subprocess.run(['docker-compose', 'build'], cwd=docker_path, shell=is_os_windows)

--- a/backend/scripts/build_image.py
+++ b/backend/scripts/build_image.py
@@ -2,11 +2,24 @@ import os
 from pathlib import Path
 import platform
 import subprocess
+import argparse
 
 cd = Path.cwd()
-docker_path = cd/'docker' if platform.system() != 'Linux' else cd/'backend'/'docker' # checking if this is a pipeline being ran, since its a linux machine
+docker_path = None # checking if this is a pipeline being ran, since its a linux machine
 is_os_windows = platform.system() == 'Windows' #windows needs shell otherwise permissions errors will not let script run processes
 
+def determine_environment():
+    print('SETTING ENVIRONMENT SPECIFIC VALUES')
+    parser = argparse.ArgumentParser(description='environment flag')
+    parser.add_argument('--env', type=str, choices=['dev', 'ci'], default='dev', help='Specify the environment (dev or ci)')
+    args = parser.parse_args()
+    global docker_path
+    if args == 'dev':
+        docker_path = cd/'docker'
+    else:
+        docker_path = cd/'backend'/'docker'
+    
+    
 def load_env_files():
     print('LOADING ENVIRONMENT VARIABLES')
     file_path = cd/'.env'

--- a/backend/scripts/run_server.py
+++ b/backend/scripts/run_server.py
@@ -2,13 +2,13 @@ import os
 import subprocess
 from pathlib import Path
 import platform
-from build_image import load_env_files, delete_old_image_and_container, build_image, determine_environment
+from build_image import load_env_files, delete_old_image_and_container, build_image, determine_docker_path
 
 '''
 Loads env variables into terminal before building then running the backend & database servers
 '''
 
-docker_path = None
+docker_path = determine_docker_path()
 is_os_windows = platform.system() == 'Windows' #windows needs shell otherwise permissions errors will not let script run processes
 
 def run_server_and_db():
@@ -17,7 +17,6 @@ def run_server_and_db():
     print(process)
     
 def main():
-    determine_environment()
     load_env_files()
     delete_old_image_and_container()
     build_image()

--- a/backend/scripts/run_server.py
+++ b/backend/scripts/run_server.py
@@ -2,13 +2,13 @@ import os
 import subprocess
 from pathlib import Path
 import platform
-from build_image import load_env_files, delete_old_image_and_container, build_image
+from build_image import load_env_files, delete_old_image_and_container, build_image, determine_environment
 
 '''
 Loads env variables into terminal before building then running the backend & database servers
 '''
 
-docker_path = Path.cwd()/'docker'
+docker_path = None
 is_os_windows = platform.system() == 'Windows' #windows needs shell otherwise permissions errors will not let script run processes
 
 def run_server_and_db():
@@ -17,6 +17,7 @@ def run_server_and_db():
     print(process)
     
 def main():
+    determine_environment()
     load_env_files()
     delete_old_image_and_container()
     build_image()

--- a/backend/scripts/run_tests.py
+++ b/backend/scripts/run_tests.py
@@ -2,13 +2,13 @@ import subprocess
 from pathlib import Path
 import platform
 from sys import exit
-from build_image import load_env_files, delete_old_image_and_container, build_image
+from build_image import load_env_files, delete_old_image_and_container, build_image, determine_environment
 
 '''
 Loads env variables into terminal before building image, then running tests inside using docker-compose
 '''
 cd = Path.cwd()
-docker_path = cd/'docker' if platform.system() != 'Linux' else cd/'backend'/'docker' # checking if this is a pipeline being ran, since its a linux machine
+docker_path = None # checking if this is a pipeline being ran, since its a linux machine
 is_os_windows = platform.system() == 'Windows' #windows needs shell otherwise permissions errors will not let script run processes
 
 def run_test_suite():
@@ -18,6 +18,7 @@ def run_test_suite():
     return process.returncode
 
 def main():
+    determine_environment()
     load_env_files()
     delete_old_image_and_container()
     build_image()

--- a/backend/scripts/run_tests.py
+++ b/backend/scripts/run_tests.py
@@ -2,13 +2,13 @@ import subprocess
 from pathlib import Path
 import platform
 from sys import exit
-from build_image import load_env_files, delete_old_image_and_container, build_image, determine_environment
+from build_image import load_env_files, delete_old_image_and_container, build_image, determine_docker_path
 
 '''
 Loads env variables into terminal before building image, then running tests inside using docker-compose
 '''
 cd = Path.cwd()
-docker_path = None # checking if this is a pipeline being ran, since its a linux machine
+docker_path = determine_docker_path()  # checking if this is a pipeline being ran, or just dev
 is_os_windows = platform.system() == 'Windows' #windows needs shell otherwise permissions errors will not let script run processes
 
 def run_test_suite():
@@ -18,7 +18,6 @@ def run_test_suite():
     return process.returncode
 
 def main():
-    determine_environment()
     load_env_files()
     delete_old_image_and_container()
     build_image()


### PR DESCRIPTION
These new changes introduce the `determine_docker_path` function that utilizes the new `--env` flag. This gives the ability to let the script know whether a script is being ran by a developer (dev) or by the CI pipeline(ci). This PR closes #90 