### PR TITLE
#110 refactor: update flow login flow for mobile

### DIFF
--- a/backend/users/authentication.py
+++ b/backend/users/authentication.py
@@ -3,17 +3,35 @@ from rest_framework_simplejwt.exceptions import AuthenticationFailed
 
 class CookieJWTAuthentication(JWTAuthentication):
     def authenticate(self, request):
-        token = request.COOKIES.get('access_token')
-
-        if not token:
-            return None
-        
-        try:
-            validated_token = self.get_validated_token(token)
-        except AuthenticationFailed as e:
-            raise AuthenticationFailed(f'Token validation failed: {str(e)}')
-        try:
-            user=self.get_user(validated_token)
-            return user, validated_token
-        except AuthenticationFailed as e:
-            raise AuthenticationFailed(f'Error retrieving user: {str(e)}')
+        if request.headers.get('Source-Header') == 'mobile':
+            token = request.headers.get('Authorization')
+            if not token:
+                return None
+            
+            try:
+                validated_token = self.get_validated_token(token)
+            except AuthenticationFailed as e:
+                raise AuthenticationFailed(f'Token validation failed: {str(e)}')
+            
+            try:
+                user=self.get_user(validated_token)
+                return user, validated_token
+            except AuthenticationFailed as e:
+                raise AuthenticationFailed(f'Error retrieving user: {str(e)}')
+            
+        elif request.headers.get('Source-Header') == 'web':
+            token = request.COOKIES.get('access_token')
+            if not token:
+                return None
+            
+            try:
+                validated_token = self.get_validated_token(token)
+            except AuthenticationFailed as e:
+                raise AuthenticationFailed(f'Token validation failed: {str(e)}')
+            try:
+                user=self.get_user(validated_token)
+                return user, validated_token
+            except AuthenticationFailed as e:
+                raise AuthenticationFailed(f'Error retrieving user: {str(e)}')
+        else:
+            raise AuthenticationFailed('Invalid source header')


### PR DESCRIPTION
All requests sent to `PeakPerformance`'s backend must now have the `Source-Header` header to establish whether the client is sending a request from the mobile app or potential web app/testing endpoints.

Subsequent mobile must also have the `Authorization` header where the `access_token` will be present.

Closes #110 